### PR TITLE
SRE-43 - Add domain and branch name to the outputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,8 @@ outputs:
     description: Deploy name for branch/environment
   url:
     description: URL for deployment
+  output:
+    description: Branch name for deployment, used in domain name.
 
 runs:
   using: node12

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ try {
   const output = branchName(github.context).toLowerCase().replace(/[^a-z0-9-]/g, "").substr(0, 63)
 
   const deploy = deployName(name, environment, github.context)
+  console.log(`name: ${deploy}`);
   core.setOutput('name', deploy);
 
   const url = `${deploy}.${domain}`

--- a/index.js
+++ b/index.js
@@ -27,13 +27,10 @@ try {
   const output = branchName(github.context).toLowerCase().replace(/[^a-z0-9-]/g, "").substr(0, 63)
 
   const deploy = deployName(name, environment, github.context)
-  console.log(`name: ${deploy}`);
   core.setOutput('name', deploy);
 
   const url = `${deploy}.${domain}`
-  console.log(`url: ${url}`);
   core.setOutput('url', url);
-  console.log(`output: ${output}`);
   core.setOutput('branch', output);
 } catch (error) {
   core.setFailed(error.message);

--- a/index.js
+++ b/index.js
@@ -2,17 +2,9 @@ const core = require('@actions/core');
 const github = require('@actions/github');
 
 function branchName(context) {
-  console.log('--------1');
-  console.log(context);
-  console.log('--------1');
-
   if (context.payload && context.payload.pull_request) {
     return context.payload.pull_request.head.ref
   }
-
-  console.log('--------2');
-  console.log(context);
-  console.log('--------2');
 
   return github.context.ref.replace(/refs\/heads\/(.*)/, '$1');
 }
@@ -32,6 +24,7 @@ try {
   const name = core.getInput('name');
   const environment = core.getInput('environment');
   const domain = core.getInput('domain');
+  const output = branchName(github.context).toLowerCase().replace(/[^a-z0-9-]/g, "").substr(0, 63)
 
   const deploy = deployName(name, environment, github.context)
   console.log(`name: ${deploy}`);
@@ -40,6 +33,8 @@ try {
   const url = `${deploy}.${domain}`
   console.log(`url: ${url}`);
   core.setOutput('url', url);
+  console.log(`output: ${output}`);
+  core.setOutput('branch', output);
 } catch (error) {
   core.setFailed(error.message);
 }

--- a/index.js
+++ b/index.js
@@ -2,9 +2,17 @@ const core = require('@actions/core');
 const github = require('@actions/github');
 
 function branchName(context) {
+  console.log('--------1');
+  console.log(context);
+  console.log('--------1');
+
   if (context.payload && context.payload.pull_request) {
     return context.payload.pull_request.head.ref
   }
+
+  console.log('--------2');
+  console.log(context);
+  console.log('--------2');
 
   return github.context.ref.replace(/refs\/heads\/(.*)/, '$1');
 }

--- a/index.js
+++ b/index.js
@@ -24,15 +24,19 @@ try {
   const name = core.getInput('name');
   const environment = core.getInput('environment');
   const domain = core.getInput('domain');
-  const output = branchName(github.context).toLowerCase().replace(/[^a-z0-9-]/g, "").substr(0, 63)
 
   const deploy = deployName(name, environment, github.context)
   console.log(`name: ${deploy}`);
   core.setOutput('name', deploy);
 
   const url = `${deploy}.${domain}`
+  console.log(`url: ${url}`);
   core.setOutput('url', url);
+
+  const output = branchName(github.context).toLowerCase().replace(/[^a-z0-9-]/g, "").substr(0, 63)
+  console.log(`output: ${output}`);
   core.setOutput('branch', output);
+
 } catch (error) {
   core.setFailed(error.message);
 }


### PR DESCRIPTION
@mikian 

# What
To update the block to return us the domain, and branch name.

# Why
So that we can create ingress hosts for each domain using the branch name, and that we can use the domain name for each app in the "update deployment status" under the deploy job in Siren.